### PR TITLE
Additional step documentation

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 167d98b
+_commit: 7bdec5d
 _src_path: gh:LabAutomationAndScreening/copier-python-package-template.git
 description: Generating programs for ViaLab to control an Integra Assist Plus liquid
     handling robot

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,2 @@
+comment:
+  require_changes: true  # only post the comment if coverage changes

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,6 @@ sphinx:
 # Optionally, but recommended,
 # declare the Python requirements required to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
+python:
+    install:
+    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,16 @@ extensions = [
     "sphinxcontrib.autodoc_pydantic",
 ]
 
+
+autodoc_pydantic_model_undoc_members = False
+autodoc_pydantic_model_show_json = False
+autodoc_pydantic_model_show_validator_members = False
+autodoc_pydantic_settings_hide_paramlist = True
+autodoc_pydantic_settings_signature_prefix = " "
+autodoc_pydantic_model_member_order = "bysource"
+autodoc_pydantic_model_members = False
+autodoc_pydantic_settings_show_field_summary = False
+
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 

--- a/docs/steps.rst
+++ b/docs/steps.rst
@@ -2,7 +2,11 @@
 
 Program Steps
 =============
+How to set the parameters for the different steps in a Vialab program.
 
+
+.. automodule:: pyalab.steps.set_volume
+    :members:
 
 .. automodule:: pyalab.steps.transfer
     :members:

--- a/src/pyalab/steps/set_volume.py
+++ b/src/pyalab/steps/set_volume.py
@@ -11,11 +11,20 @@ from .base import ul_to_xml
 
 
 class SetVolume(Step):
+    """Specify the volume of liquid in the labware.
+
+    Can be used to initially define it at the beginning of a protocol, or after a manual filling step.
+    """
+
     type = "ManualFilling"
     plate: Plate
+    """The plate to set the volume for."""
     section_index: int | None = None
+    """The section of the Deck holding the plate."""
     column_index: int
+    """The column within the plate to set the volume for."""
     volume: float = Field(ge=0)
+    """The specified volume (µl)."""
 
     @override
     def _add_value_groups(self) -> None:
@@ -50,4 +59,9 @@ class SetVolume(Step):
 
 
 class SetInitialVolume(SetVolume):
+    """Must be used as the first step in the program that set's the volume.
+
+    Uses the same parameters as SetVolume.
+    """
+
     type = "ManualFilling_First"

--- a/src/pyalab/steps/transfer.py
+++ b/src/pyalab/steps/transfer.py
@@ -25,7 +25,7 @@ class Transfer(Step):
     destination_column_index: int
     """The column index to dispense into."""
     volume: float
-    """The volume to transfer."""
+    """The volume to transfer (µl)."""
 
     @override
     def _add_value_groups(self) -> None:


### PR DESCRIPTION
 ## Why is this change necessary?
Not all steps were documented in Sphinx.  Also, readthedocs was failing because dependencies weren't installed.


 ## How does this change address the issue?
Fixes readthedocs config to actually install the requirements. Documents the set volume steps.


 ## What side effects does this change have?
None


 ## How is this change tested?
Local doc build
