### PR TITLE
Support Codespaces

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: d36c61b
+_commit: dcf5428
 _src_path: gh:LabAutomationAndScreening/copier-python-package-template.git
 description: Generating programs for Vialab to control an Integra Assist Plus liquid
     handling robot

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: d7cda39
+_commit: d36c61b
 _src_path: gh:LabAutomationAndScreening/copier-python-package-template.git
 description: Generating programs for Vialab to control an Integra Assist Plus liquid
     handling robot

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,14 +3,16 @@
   "service": "devcontainer",
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
   "features": {
-    "ghcr.io/devcontainers/features/aws-cli:1": { // view latest version https://raw.githubusercontent.com/aws/aws-cli/v2/CHANGELOG.rst
+    "ghcr.io/devcontainers/features/aws-cli:1": {
+      // view latest version https://raw.githubusercontent.com/aws/aws-cli/v2/CHANGELOG.rst
       "version": "2.19.3"
     },
-    "ghcr.io/devcontainers/features/python:1": { // https://github.com/devcontainers/features/tree/main/src/python
+    "ghcr.io/devcontainers/features/python:1": {
+      // https://github.com/devcontainers/features/tree/main/src/python
       "version": "3.12.7",
       "installTools": false,
       "optimize": true
-    },
+    }
   },
   "customizations": {
     "vscode": {
@@ -32,22 +34,27 @@
         "samuelcolvin.jinjahtml@0.20.0",
         "tamasfe.even-better-toml@0.19.2",
         "emilast.LogFileHighlighter@3.3.3",
+        "esbenp.prettier-vscode@11.0.0"
       ],
       "settings": {
-        "editor.accessibilitySupport": "off", // turn off annoying sounds
+        "editor.accessibilitySupport": "off", // turn off sounds
         "extensions.autoUpdate": false,
         "extensions.autoCheckUpdates": false,
         "[python]": {
           "editor.formatOnSave": true,
-          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.defaultFormatter": "charliermarsh.ruff"
         },
         "ruff.nativeServer": "on",
         // TODO: see if there's a way to specify different configurations for different folders
         "ruff.configuration": "/workspaces/pyalab/ruff-test.toml", // use the test configuration since it's less restrictive and won't show false positives and underline things
-      },
-    },
+        "[jsonc][json]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode",
+          "editor.formatOnSave": true
+        }
+      }
+    }
   },
-  //"initializeCommand": "sh .devcontainer/initialize-command.sh",
+  "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": ".devcontainer/post-start-command.sh",
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -56,5 +56,5 @@
   },
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
-  "postStartCommand": ".devcontainer/post-start-command.sh",
+  "postStartCommand": "sh .devcontainer/post-start-command.sh"
 }

--- a/.devcontainer/install-ci-tooling.sh
+++ b/.devcontainer/install-ci-tooling.sh
@@ -1,7 +1,7 @@
 # can pass in the full major.minor.patch version of python as an optional argument
 set -ex
 
-curl -LsSf https://astral.sh/uv/0.5.9/install.sh | sh
+curl -LsSf https://astral.sh/uv/0.5.10/install.sh | sh
 uv --version
 # TODO: add uv autocompletion to the shell https://docs.astral.sh/uv/getting-started/installation/#shell-autocompletion
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -152,7 +152,7 @@ repos:
         exclude: docs/.*\.rst$
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: fc6ef5d0dd21a2a98a7fc6956e4f16166cb6562a  # frozen: v0.8.3
+    rev: f0b5944bef86f50d875305821a0ab0d8c601e465  # frozen: v0.8.4
     hooks:
     -   id: ruff
         name: ruff-src

--- a/sh.bat
+++ b/sh.bat
@@ -1,0 +1,1 @@
+echo "Dummy file to avoid actually executing a shell script from a Windows host"


### PR DESCRIPTION
 ## Link to Issue or Slack thread
https://github.com/LabAutomationAndScreening/pyalab/issues/10


 ## Why is this change necessary?
Previously, codespaces failed to build because the environment ran out of space


 ## How does this change address the issue?
Enables running docker image prune as the initialize command


 ## What side effects does this change have?
None


 ## How is this change tested?
Built a codespace, and a devcontainer locally on windows PC


 ## Other
Bumped some pre-commit hooks and ruff