### PR TITLE
DRY up steps

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: dcf5428
+_commit: 1bad193
 _src_path: gh:LabAutomationAndScreening/copier-python-package-template.git
 description: Generating programs for Vialab to control an Integra Assist Plus liquid
     handling robot

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 1bad193
+_commit: 4af6abc
 _src_path: gh:LabAutomationAndScreening/copier-python-package-template.git
 description: Generating programs for Vialab to control an Integra Assist Plus liquid
     handling robot

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 4af6abc
+_commit: f131837
 _src_path: gh:LabAutomationAndScreening/copier-python-package-template.git
 description: Generating programs for Vialab to control an Integra Assist Plus liquid
     handling robot

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=2.10.3",
+    "inflection>=0.5.1",
     "lxml>=4.9.2,<5", # as of 2024-12-18, Python3.13 does not appear to support lxml 5
 ]
 

--- a/src/pyalab/steps/base.py
+++ b/src/pyalab/steps/base.py
@@ -4,6 +4,7 @@ from abc import ABC
 from abc import abstractmethod
 from typing import ClassVar
 
+from inflection import camelize
 from lxml import etree
 from lxml.etree import _Element
 from pydantic import BaseModel
@@ -17,6 +18,18 @@ def ul_to_xml(volume: float) -> int:
 
 
 SPECIAL_CHARS = ('"', "[", "]", "{", "}")
+
+
+class WellOffsets(BaseModel, frozen=True):
+    deck_section: int
+    sub_section: int
+    offset_x: int
+    offset_y: int
+
+    model_config = {
+        "populate_by_name": True,  # Allow population by field name
+        "alias_generator": camelize,  # Convert field names to camelCase
+    }
 
 
 class Step(BaseModel, ABC):

--- a/src/pyalab/steps/base.py
+++ b/src/pyalab/steps/base.py
@@ -45,6 +45,17 @@ class DeckSection(BaseModel, frozen=True):
     }
 
 
+class Section(BaseModel, frozen=True):
+    """Some steps call it Section instead of DeckSection."""
+
+    section: int
+    sub_section: int
+    model_config = {
+        "populate_by_name": True,  # Allow population by field name
+        "alias_generator": camelize,  # Convert field names to camelCase
+    }
+
+
 class WellOffsets(BaseModel, frozen=True):
     deck_section: int
     sub_section: int

--- a/src/pyalab/steps/base.py
+++ b/src/pyalab/steps/base.py
@@ -36,6 +36,15 @@ class WellRowCol(BaseModel, frozen=True):
     }
 
 
+class DeckSection(BaseModel, frozen=True):
+    deck_section: int
+    sub_section: int
+    model_config = {
+        "populate_by_name": True,  # Allow population by field name
+        "alias_generator": camelize,  # Convert field names to camelCase
+    }
+
+
 class WellOffsets(BaseModel, frozen=True):
     deck_section: int
     sub_section: int

--- a/src/pyalab/steps/base.py
+++ b/src/pyalab/steps/base.py
@@ -8,9 +8,9 @@ from inflection import camelize
 from lxml import etree
 from lxml.etree import _Element
 from pydantic import BaseModel
+from pydantic import Field
 
 from pyalab.pipette import Tip
-from pydantic import Field
 
 
 def ul_to_xml(volume: float) -> int:

--- a/src/pyalab/steps/base.py
+++ b/src/pyalab/steps/base.py
@@ -10,6 +10,7 @@ from lxml.etree import _Element
 from pydantic import BaseModel
 
 from pyalab.pipette import Tip
+from pydantic import Field
 
 
 def ul_to_xml(volume: float) -> int:
@@ -18,6 +19,21 @@ def ul_to_xml(volume: float) -> int:
 
 
 SPECIAL_CHARS = ('"', "[", "]", "{", "}")
+
+ALIASES = {"column_index": "Item1", "row_index": "Item2"}
+
+
+def alias_generator(name: str) -> str:
+    return ALIASES.get(name, name)
+
+
+class WellRowCol(BaseModel, frozen=True):
+    column_index: int = Field(ge=0)
+    row_index: int = Field(ge=0)
+    model_config = {
+        "populate_by_name": True,  # Allow population by field name
+        "alias_generator": alias_generator,
+    }
 
 
 class WellOffsets(BaseModel, frozen=True):

--- a/src/pyalab/steps/set_volume.py
+++ b/src/pyalab/steps/set_volume.py
@@ -6,7 +6,9 @@ from pydantic import Field
 
 from pyalab.plate import Plate
 
+from .base import Section
 from .base import Step
+from .base import WellRowCol
 from .base import ul_to_xml
 
 
@@ -28,17 +30,22 @@ class SetVolume(Step):
 
     @override
     def _add_value_groups(self) -> None:
+        assert self.section_index is not None, "section_index must be set prior to creating XML"
+        well = WellRowCol(
+            column_index=self.column_index,
+            row_index=0,  # TODO: handle row index
+        )
+        deck_section = Section(
+            section=self.section_index,
+            sub_section=-1,  # TODO: figure out what subsection means
+        )
         volume_info: list[dict[str, Any]] = [
             {
                 "WellCoordinates": [
-                    {
-                        "Item1": self.column_index,
-                        "Item2": 0,  # TODO: handle row index
-                    }
+                    well.model_dump(by_alias=True),
                 ],
                 "Volume": ul_to_xml(self.volume),
-                "Section": self.section_index,
-                "SubSection": -1,  # TODO: figure out what subsection means
+                **deck_section.model_dump(by_alias=True),
                 "Spacing": 900,  # TODO: handle spacing other than 96-well plate
                 "ColorIndex": 1,  # TODO: figure out if/when this changes
                 "DeckId": "00000000-0000-0000-0000-000000000000",  # TODO: figure out if this has any meaning

--- a/src/pyalab/steps/transfer.py
+++ b/src/pyalab/steps/transfer.py
@@ -5,6 +5,7 @@ from typing import override
 from pyalab.plate import Plate
 
 from .base import Step
+from .base import WellOffsets
 from .base import ul_to_xml
 
 
@@ -29,6 +30,7 @@ class Transfer(Step):
 
     @override
     def _add_value_groups(self) -> None:
+        assert self.source_section_index is not None, "Source section index must be set prior to creating XML"
         source_info: list[dict[str, Any]] = [
             {
                 "Wells": [
@@ -70,12 +72,9 @@ class Transfer(Step):
                     "WellOffsets",
                     json.dumps(
                         [
-                            {
-                                "DeckSection": self.source_section_index,
-                                "SubSection": -1,
-                                "OffsetX": 0,
-                                "OffsetY": 0,
-                            }
+                            WellOffsets(
+                                deck_section=self.source_section_index, sub_section=-1, offset_x=0, offset_y=0
+                            ).model_dump(by_alias=True)
                         ]
                     ),
                 ),

--- a/src/pyalab/steps/transfer.py
+++ b/src/pyalab/steps/transfer.py
@@ -5,7 +5,8 @@ from typing import override
 from pyalab.plate import Plate
 
 from .base import Step
-from .base import WellOffsets, WellRowCol
+from .base import WellOffsets
+from .base import WellRowCol
 from .base import ul_to_xml
 
 

--- a/src/pyalab/steps/transfer.py
+++ b/src/pyalab/steps/transfer.py
@@ -5,7 +5,7 @@ from typing import override
 from pyalab.plate import Plate
 
 from .base import Step
-from .base import WellOffsets
+from .base import WellOffsets, WellRowCol
 from .base import ul_to_xml
 
 
@@ -31,14 +31,16 @@ class Transfer(Step):
     @override
     def _add_value_groups(self) -> None:
         assert self.source_section_index is not None, "Source section index must be set prior to creating XML"
+        assert self.destination_section_index is not None, "Destination section index must be set prior to creating XML"
+        source_well = WellRowCol(column_index=self.source_column_index, row_index=0).model_dump(
+            by_alias=True
+        )  # TODO: handle row index
+        destination_well = WellRowCol(column_index=self.destination_column_index, row_index=0).model_dump(
+            by_alias=True
+        )  # TODO: handle row index
         source_info: list[dict[str, Any]] = [
             {
-                "Wells": [
-                    {
-                        "Item1": self.source_column_index,
-                        "Item2": 0,  # TODO: handle row index
-                    }
-                ],
+                "Wells": [source_well],
                 "DeckSection": self.source_section_index,
                 "SubSection": -1,  # TODO: figure out what subsection means
                 "Spacing": 900,  # TODO: handle spacing other than 96-well plate
@@ -49,12 +51,7 @@ class Transfer(Step):
         ]
         target_info: list[dict[str, Any]] = [
             {
-                "Wells": [
-                    {
-                        "Item1": self.destination_column_index,
-                        "Item2": 0,  # TODO: handle row index
-                    }
-                ],
+                "Wells": [destination_well],
                 "DeckSection": self.destination_section_index,
                 "SubSection": -1,  # TODO: figure out what subsection means
                 "Spacing": 900,  # TODO: handle spacing other than 96-well plate
@@ -88,12 +85,9 @@ class Transfer(Step):
                     "WellOffsets",
                     json.dumps(
                         [
-                            {
-                                "DeckSection": self.destination_section_index,
-                                "SubSection": -1,
-                                "OffsetX": 0,
-                                "OffsetY": 0,
-                            }
+                            WellOffsets(
+                                deck_section=self.destination_section_index, sub_section=-1, offset_x=0, offset_y=0
+                            ).model_dump(by_alias=True)
                         ]
                     ),
                 ),
@@ -109,7 +103,7 @@ class Transfer(Step):
                     json.dumps(
                         [
                             {
-                                "Well": {"Item1": self.destination_column_index, "Item2": 0},
+                                "Well": destination_well,
                                 "DeckSection": self.destination_section_index,
                                 "SubSection": -1,
                                 "Volume": ul_to_xml(self.volume),
@@ -157,7 +151,7 @@ class Transfer(Step):
                     json.dumps(
                         [
                             {
-                                "Well": {"Item1": self.source_column_index, "Item2": 0},
+                                "Well": source_well,
                                 "DeckSection": self.source_section_index,
                                 "SubSection": -1,
                                 "StartHeight": 325,  # TODO: figure out how these height values are determined
@@ -204,7 +198,7 @@ class Transfer(Step):
                     json.dumps(
                         [
                             {
-                                "Well": {"Item1": self.destination_column_index, "Item2": 0},
+                                "Well": destination_well,
                                 "DeckSection": self.destination_section_index,
                                 "SubSection": -1,
                                 "StartHeight": 325,  # TODO: figure out how these height values are determined
@@ -273,7 +267,7 @@ class Transfer(Step):
                     json.dumps(
                         obj=[
                             {
-                                "Well": {"Item1": self.source_column_index, "Item2": 0},
+                                "Well": source_well,
                                 "DeckSection": self.source_section_index,
                                 "SubSection": -1,
                                 "Volume": 5000,  # TODO: implement mixing volume
@@ -306,7 +300,7 @@ class Transfer(Step):
                     json.dumps(
                         obj=[
                             {
-                                "Well": {"Item1": self.source_column_index, "Item2": 0},
+                                "Well": source_well,
                                 "DeckSection": self.source_section_index,
                                 "SubSection": -1,
                                 "StartHeight": 325,  # TODO: figure out how these height values are determined
@@ -340,7 +334,7 @@ class Transfer(Step):
                     json.dumps(
                         obj=[
                             {
-                                "Well": {"Item1": self.destination_column_index, "Item2": 0},
+                                "Well": destination_well,
                                 "DeckSection": self.destination_section_index,
                                 "SubSection": -1,
                                 "Volume": 5000,  # TODO: implement mixing volume
@@ -373,7 +367,7 @@ class Transfer(Step):
                     json.dumps(
                         obj=[
                             {
-                                "Well": {"Item1": self.destination_column_index, "Item2": 0},
+                                "Well": destination_well,
                                 "DeckSection": self.destination_section_index,
                                 "SubSection": -1,
                                 "StartHeight": 325,  # TODO: figure out how these height values are determined

--- a/src/pyalab/steps/transfer.py
+++ b/src/pyalab/steps/transfer.py
@@ -4,6 +4,7 @@ from typing import override
 
 from pyalab.plate import Plate
 
+from .base import DeckSection
 from .base import Step
 from .base import WellOffsets
 from .base import WellRowCol
@@ -33,6 +34,13 @@ class Transfer(Step):
     def _add_value_groups(self) -> None:
         assert self.source_section_index is not None, "Source section index must be set prior to creating XML"
         assert self.destination_section_index is not None, "Destination section index must be set prior to creating XML"
+        source_deck_section_model = DeckSection(
+            deck_section=self.source_section_index,
+            sub_section=-1,  # TODO: figure out what subsection means
+        )
+        source_deck_section = source_deck_section_model.model_dump(by_alias=True)
+        destination_deck_section_model = DeckSection(deck_section=self.destination_section_index, sub_section=-1)
+        destination_deck_section = destination_deck_section_model.model_dump(by_alias=True)
         source_well = WellRowCol(column_index=self.source_column_index, row_index=0).model_dump(
             by_alias=True
         )  # TODO: handle row index
@@ -42,8 +50,7 @@ class Transfer(Step):
         source_info: list[dict[str, Any]] = [
             {
                 "Wells": [source_well],
-                "DeckSection": self.source_section_index,
-                "SubSection": -1,  # TODO: figure out what subsection means
+                **source_deck_section,
                 "Spacing": 900,  # TODO: handle spacing other than 96-well plate
                 "DeckId": "00000000-0000-0000-0000-000000000000",  # TODO: figure out if this has any meaning
                 "WorkingDirectionExtended": 0,  # TODO: figure out what this is
@@ -53,8 +60,7 @@ class Transfer(Step):
         target_info: list[dict[str, Any]] = [
             {
                 "Wells": [destination_well],
-                "DeckSection": self.destination_section_index,
-                "SubSection": -1,  # TODO: figure out what subsection means
+                **destination_deck_section,
                 "Spacing": 900,  # TODO: handle spacing other than 96-well plate
                 "DeckId": "00000000-0000-0000-0000-000000000000",  # TODO: figure out if this has any meaning
                 "WorkingDirectionExtended": 0,  # TODO: figure out what this is
@@ -70,9 +76,9 @@ class Transfer(Step):
                     "WellOffsets",
                     json.dumps(
                         [
-                            WellOffsets(
-                                deck_section=self.source_section_index, sub_section=-1, offset_x=0, offset_y=0
-                            ).model_dump(by_alias=True)
+                            WellOffsets(offset_x=0, offset_y=0, **source_deck_section_model.model_dump()).model_dump(
+                                by_alias=True
+                            )
                         ]
                     ),
                 ),
@@ -87,7 +93,7 @@ class Transfer(Step):
                     json.dumps(
                         [
                             WellOffsets(
-                                deck_section=self.destination_section_index, sub_section=-1, offset_x=0, offset_y=0
+                                offset_x=0, offset_y=0, **destination_deck_section_model.model_dump()
                             ).model_dump(by_alias=True)
                         ]
                     ),
@@ -105,8 +111,7 @@ class Transfer(Step):
                         [
                             {
                                 "Well": destination_well,
-                                "DeckSection": self.destination_section_index,
-                                "SubSection": -1,
+                                **destination_deck_section,
                                 "Volume": ul_to_xml(self.volume),
                                 "TipID": self.tip_id,
                                 "Multiplier": 1,
@@ -153,8 +158,7 @@ class Transfer(Step):
                         [
                             {
                                 "Well": source_well,
-                                "DeckSection": self.source_section_index,
-                                "SubSection": -1,
+                                **source_deck_section,
                                 "StartHeight": 325,  # TODO: figure out how these height values are determined
                                 "EndHeight": 325,
                                 "TipID": self.tip_id,
@@ -168,8 +172,7 @@ class Transfer(Step):
                     json.dumps(
                         [
                             {
-                                "DeckSection": self.source_section_index,
-                                "SubSection": -1,
+                                **source_deck_section,
                                 "HeightConfigType": True,
                                 "WellBottomOffset": 0,
                             }
@@ -181,8 +184,7 @@ class Transfer(Step):
                     json.dumps(
                         [
                             {
-                                "DeckSection": self.source_section_index,
-                                "SubSection": -1,
+                                **source_deck_section,
                                 "WellBottomOffset": 200,
                                 "TipID": self.tip_id,
                             }
@@ -200,8 +202,7 @@ class Transfer(Step):
                         [
                             {
                                 "Well": destination_well,
-                                "DeckSection": self.destination_section_index,
-                                "SubSection": -1,
+                                **destination_deck_section,
                                 "StartHeight": 325,  # TODO: figure out how these height values are determined
                                 "EndHeight": 325,
                                 "TipID": self.tip_id,
@@ -215,8 +216,7 @@ class Transfer(Step):
                     json.dumps(
                         [
                             {
-                                "DeckSection": self.destination_section_index,
-                                "SubSection": -1,
+                                **destination_deck_section,
                                 "HeightConfigType": True,
                                 "WellBottomOffset": 0,
                             }
@@ -228,8 +228,7 @@ class Transfer(Step):
                     json.dumps(
                         [
                             {
-                                "DeckSection": self.destination_section_index,
-                                "SubSection": -1,
+                                **destination_deck_section,
                                 "WellBottomOffset": 200,
                                 "TipID": self.tip_id,
                             }
@@ -269,8 +268,7 @@ class Transfer(Step):
                         obj=[
                             {
                                 "Well": source_well,
-                                "DeckSection": self.source_section_index,
-                                "SubSection": -1,
+                                **source_deck_section,
                                 "Volume": 5000,  # TODO: implement mixing volume
                                 "TipID": self.tip_id,
                                 "Multiplier": 1,
@@ -287,8 +285,7 @@ class Transfer(Step):
                     json.dumps(
                         obj=[
                             {
-                                "DeckSection": self.source_section_index,
-                                "SubSection": -1,
+                                **source_deck_section,
                                 "HeightConfigType": True,
                                 "WellBottomOffset": 0,
                             }
@@ -302,8 +299,7 @@ class Transfer(Step):
                         obj=[
                             {
                                 "Well": source_well,
-                                "DeckSection": self.source_section_index,
-                                "SubSection": -1,
+                                **source_deck_section,
                                 "StartHeight": 325,  # TODO: figure out how these height values are determined
                                 "EndHeight": 0,
                                 "TipID": self.tip_id,
@@ -336,8 +332,7 @@ class Transfer(Step):
                         obj=[
                             {
                                 "Well": destination_well,
-                                "DeckSection": self.destination_section_index,
-                                "SubSection": -1,
+                                **destination_deck_section,
                                 "Volume": 5000,  # TODO: implement mixing volume
                                 "TipID": self.tip_id,
                                 "Multiplier": 1,
@@ -354,8 +349,7 @@ class Transfer(Step):
                     json.dumps(
                         obj=[
                             {
-                                "DeckSection": self.destination_section_index,
-                                "SubSection": -1,
+                                **destination_deck_section,
                                 "HeightConfigType": True,
                                 "WellBottomOffset": 0,
                             }
@@ -369,8 +363,7 @@ class Transfer(Step):
                         obj=[
                             {
                                 "Well": destination_well,
-                                "DeckSection": self.destination_section_index,
-                                "SubSection": -1,
+                                **destination_deck_section,
                                 "StartHeight": 325,  # TODO: figure out how these height values are determined
                                 "EndHeight": 0,
                                 "TipID": self.tip_id,
@@ -391,8 +384,7 @@ class Transfer(Step):
                     json.dumps(
                         obj=[
                             {
-                                "DeckSection": self.destination_section_index,
-                                "SubSection": -1,
+                                **destination_deck_section,
                                 "Type": False,
                                 "Height": 1406,  # TODO: implement tip touch
                                 "Distance": 225,

--- a/uv.lock
+++ b/uv.lock
@@ -177,6 +177,15 @@ wheels = [
 ]
 
 [[package]]
+name = "inflection"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple/" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/7e/691d061b7329bc8d54edbf0ec22fbfb2afe61facb681f9aaa9bff7a27d04/inflection-0.5.1.tar.gz", hash = "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417", size = 15091 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/91/aa6bde563e0085a02a435aa99b49ef75b0a4b062635e606dab23ce18d720/inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2", size = 9454 },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple/" }
@@ -291,6 +300,7 @@ name = "pyalab"
 version = "0.1.1"
 source = { editable = "." }
 dependencies = [
+    { name = "inflection" },
     { name = "lxml" },
     { name = "pydantic" },
 ]
@@ -311,6 +321,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "inflection", specifier = ">=0.5.1" },
     { name = "lxml", specifier = ">=4.9.2,<5" },
     { name = "pydantic", specifier = ">=2.10.3" },
 ]


### PR DESCRIPTION
 ## Why is this change necessary?
There was some duplication in the generation of the steps.


 ## How does this change address the issue?
Creates some pydantic models for some of the JSON representation within the steps.

Initializes models for Well and Deck Section at the beginning of add_values, and then uses them everywhere in the XML generation.


 ## What side effects does this change have?
Cleaner code.


 ## How is this change tested?
Existing snapshot tests.

