### PR TITLE
Run CI tests on Windows

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: a43f959
+_commit: '8451583'
 _src_path: gh:LabAutomationAndScreening/copier-python-package-template.git
 create_docs: true
 description: Generating programs for Vialab to control an Integra Assist Plus liquid

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: '6989630'
+_commit: a43f959
 _src_path: gh:LabAutomationAndScreening/copier-python-package-template.git
 create_docs: true
 description: Generating programs for Vialab to control an Integra Assist Plus liquid

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: 9d860be
+_commit: b618fe4
 _src_path: gh:LabAutomationAndScreening/copier-python-package-template.git
 create_docs: true
 description: Generating programs for Vialab to control an Integra Assist Plus liquid
@@ -12,4 +12,5 @@ python_ci_versions:
 python_version: 3.12.7
 repo_name: pyalab
 ssh_port_number: 56475
+use_windows_in_ci: true
 

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: b618fe4
+_commit: '6989630'
 _src_path: gh:LabAutomationAndScreening/copier-python-package-template.git
 create_docs: true
 description: Generating programs for Vialab to control an Integra Assist Plus liquid

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: '8451583'
+_commit: v0.0.1
 _src_path: gh:LabAutomationAndScreening/copier-python-package-template.git
 create_docs: true
 description: Generating programs for Vialab to control an Integra Assist Plus liquid

--- a/.github/actions/install_deps_uv/action.yml
+++ b/.github/actions/install_deps_uv/action.yml
@@ -37,24 +37,24 @@ runs:
       shell: pwsh
 
     - name: Install Dependencies (Linux)
-      if: ${{ inputs.uv-sync }} && runner.os == 'Linux'
+      if: ${{ inputs.uv-sync && runner.os == 'Linux' }}
       run: |
         sh .devcontainer/manual-setup-deps.sh ${{ env.PYTHON_VERSION }}
       shell: bash
 
     - name: Install Dependencies (Windows)
-      if: ${{ inputs.uv-sync }} && runner.os == 'Windows'
+      if: ${{ inputs.uv-sync && runner.os == 'Windows' }}
       run: .github/actions/install_deps_uv/manual-setup-deps.ps1 ${{ env.PYTHON_VERSION }}
       shell: pwsh
 
     - name: List Dependencies (Linux)
-      if: ${{ inputs.uv-sync }} && runner.os == 'Linux'
+      if: ${{ inputs.uv-sync && runner.os == 'Linux' }}
       run: |
         uv pip list
       shell: bash
 
     - name: List Dependencies (Windows)
-      if: ${{ inputs.uv-sync }} && runner.os == 'Windows'
+      if: ${{ inputs.uv-sync && runner.os == 'Windows' }}
       run: |
         & uv pip list
       shell: pwsh

--- a/.github/actions/install_deps_uv/action.yml
+++ b/.github/actions/install_deps_uv/action.yml
@@ -26,13 +26,35 @@ runs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
-    - name: Install Tooling
+    - name: Install Tooling (Linux)
+      if: runner.os == 'Linux'
       run: sh .devcontainer/install-ci-tooling.sh ${{ env.PYTHON_VERSION }}
       shell: bash
 
-    - name: Install Dependencies
-      if: ${{ inputs.uv-sync }}
+    - name: Install Tooling (Windows)
+      if: runner.os == 'Windows'
+      run: .github/actions/install_deps_uv/install-ci-tooling.ps1 ${{ env.PYTHON_VERSION }}
+      shell: pwsh
+
+    - name: Install Dependencies (Linux)
+      if: ${{ inputs.uv-sync }} && runner.os == 'Linux'
       run: |
         sh .devcontainer/manual-setup-deps.sh ${{ env.PYTHON_VERSION }}
+      shell: bash
+
+    - name: Install Dependencies (Windows)
+      if: ${{ inputs.uv-sync }} && runner.os == 'Windows'
+      run: .github/actions/install_deps_uv/manual-setup-deps.ps1 ${{ env.PYTHON_VERSION }}
+      shell: pwsh
+
+    - name: List Dependencies (Linux)
+      if: ${{ inputs.uv-sync }} && runner.os == 'Linux'
+      run: |
         uv pip list
       shell: bash
+
+    - name: List Dependencies (Windows)
+      if: ${{ inputs.uv-sync }} && runner.os == 'Windows'
+      run: |
+        & uv pip list
+      shell: pwsh

--- a/.github/actions/install_deps_uv/install-ci-tooling.ps1
+++ b/.github/actions/install_deps_uv/install-ci-tooling.ps1
@@ -1,0 +1,27 @@
+
+# Set strict error handling
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+irm https://astral.sh/uv/0.5.10/install.ps1 | iex
+& uv --version
+
+# Ensure that uv won't use the default system Python
+$default_version = "3.12.7"
+
+# Check if an argument is provided; if not, use the default version
+if ($args.Count -eq 0) {
+    $input_arg = $default_version
+} else {
+    $input_arg = $args[0]
+}
+
+
+$env:UV_PYTHON = "$input"
+$env:UV_PYTHON_PREFERENCE="only-system"
+
+& uv tool install 'copier==9.4.1' --with 'copier-templates-extensions==0.3.0'
+
+& uv tool install 'pre-commit==4.0.1'
+
+& uv tool list

--- a/.github/actions/install_deps_uv/install-ci-tooling.ps1
+++ b/.github/actions/install_deps_uv/install-ci-tooling.ps1
@@ -4,6 +4,10 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = "Stop"
 
 irm https://astral.sh/uv/0.5.10/install.ps1 | iex
+
+# Add uv to path (in github runner)
+$env:Path = "C:\Users\runneradmin\.local\bin;$env:Path"
+
 & uv --version
 
 # Ensure that uv won't use the default system Python

--- a/.github/actions/install_deps_uv/manual-setup-deps.ps1
+++ b/.github/actions/install_deps_uv/manual-setup-deps.ps1
@@ -20,6 +20,8 @@ if ($args.Count -eq 0) {
 $env:UV_PYTHON = "$input"
 $env:UV_PYTHON_PREFERENCE="only-system"
 
+# Add uv to path (in github runner)
+$env:Path = "C:\Users\runneradmin\.local\bin;$env:Path"
 
 
 $SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Definition

--- a/.github/actions/install_deps_uv/manual-setup-deps.ps1
+++ b/.github/actions/install_deps_uv/manual-setup-deps.ps1
@@ -1,0 +1,31 @@
+#!/usr/bin/env pwsh
+# can pass in the full major.minor.patch version of python as an optional argument
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+
+
+# Ensure that uv won't use the default system Python
+$default_version="3.12.7"
+
+# Check if an argument is provided; if not, use the default version
+if ($args.Count -eq 0) {
+    $input_arg = $default_version
+} else {
+    $input_arg = $args[0]
+}
+
+
+$env:UV_PYTHON = "$input"
+$env:UV_PYTHON_PREFERENCE="only-system"
+
+
+
+$SCRIPT_DIR = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$PROJECT_ROOT_DIR = Resolve-Path (Join-Path $SCRIPT_DIR "..")
+
+# Ensure that the lock file is in a good state
+& uv lock --check --directory $PROJECT_ROOT_DIR
+
+& uv sync --frozen --directory $PROJECT_ROOT_DIR

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,7 @@ jobs:
       matrix:
         os:
           - "ubuntu-24.04"
+          - windows-2022
         python-version:
 
           - 3.12.7


### PR DESCRIPTION
 ## Link to Issue or Slack thread
https://github.com/LabAutomationAndScreening/pyalab/issues/23


 ## Why is this change necessary?
Vialab itself runs on Windows, so people may want to directly run pyalab on their Windows PC running ViaLab. So Windows should be fully supported by CI tests


 ## How does this change address the issue?
Pulls in change from copier template to run CI in Windows


 ## What side effects does this change have?
CI takes longer


 ## How is this change tested?
In CI


