### PR TITLE
Include Integra XML definition files in package

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier
-_commit: v0.0.50
+_commit: v0.0.52
 _src_path: gh:LabAutomationAndScreening/copier-python-package-template.git
 create_docs: true
 description: Generating programs for Vialab to control an Integra Assist Plus liquid

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -61,5 +61,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 04ec2046 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 1167b437 # spellchecker:disable-line
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -61,5 +61,5 @@
   "initializeCommand": "sh .devcontainer/initialize-command.sh",
   "onCreateCommand": "sh .devcontainer/on-create-command.sh",
   "postStartCommand": "sh .devcontainer/post-start-command.sh"
-  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 1167b437 # spellchecker:disable-line
+  // Devcontainer context hash (do not manually edit this, it's managed by a pre-commit hook): 9be2b25c # spellchecker:disable-line
 }

--- a/.devcontainer/install-ci-tooling.py
+++ b/.devcontainer/install-ci-tooling.py
@@ -7,8 +7,8 @@ import sys
 import tempfile
 from pathlib import Path
 
-UV_VERSION = "0.8.17"
-PNPM_VERSION = "10.16.1"
+UV_VERSION = "0.8.22"
+PNPM_VERSION = "10.17.1"
 COPIER_VERSION = "9.10.2"
 COPIER_TEMPLATE_EXTENSIONS_VERSION = "0.3.3"
 PRE_COMMIT_VERSION = "4.3.0"
@@ -65,7 +65,7 @@ def main():
             )
         else:
             _ = subprocess.run(
-                f"curl -fsSL https://astral.sh/uv/{UV_VERSION}/install.sh | sh",
+                f"curl -fsSL --connect-timeout 20 --max-time 40 --retry 3 --retry-delay 5 --retry-connrefused --proto '=https' https://astral.sh/uv/{UV_VERSION}/install.sh | sh",
                 check=True,
                 shell=True,
                 env=uv_env,

--- a/.github/workflows/get-values.yaml
+++ b/.github/workflows/get-values.yaml
@@ -24,8 +24,16 @@ jobs:
       dependabot-commit-created: ${{ steps.update-hash.outputs.commit-created }}
       pr-short-num: ${{ steps.find-pr-num.outputs.number }}
     steps:
+      - name: Display full GitHub context
+        run: |
+          jq . <<'JSON'
+          ${{ toJSON(github) }}
+          JSON
+
       - name: Checkout code
         uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Update Devcontainer Hash
         if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'push' }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -35,10 +35,13 @@ jobs:
         uses: actions/checkout@v5.0.0
         with:
           ref: ${{ github.ref_name }} # explicitly get the head of the branch, which will include any new commits pushed if this is a dependabot branch
+          persist-credentials: false
 
       - name: Checkout code not during push
         if: ${{ github.event_name != 'push' }}
         uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Install latest versions of packages
         uses: ./.github/actions/install_deps

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -102,8 +102,8 @@ repos:
               .*pyrightconfig\.json|
           )$
 
-  - repo: https://github.com/pre-commit/mirrors-prettier # TODO: switch to a different approach...this was archived in 2024
-    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: 5ba47274f9b181bce26a5150a725577f3c336011  # frozen: v3.6.2
     hooks:
       - id: prettier
         # TODO: get template YAML and MD files more in line with prettier expectations so we can start using prettier on those too
@@ -125,6 +125,7 @@ repos:
               .*/vendor_files/.*|
               .*/schema.graphql|
               .*generated/graphql.ts|
+              template/.*|
           )$
         files: (.*.json)|(.*.ts)|(.*.jsx)|(.*.tsx)|(.*.yaml)|(.*.yml)|(.*.md)|(.*.html)|(.*.css)|(.*.scss)|(.*.less)|(.*.vue)|(.*.graphql)|(.*.gql)
 
@@ -178,6 +179,11 @@ repos:
       - id: check-merge-conflict
       - id: check-case-conflict
 
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 83987cd6ad8943c7f029b500b14aaf82c00a01fa  # frozen: 0.34.0
+    hooks:
+      - id: check-github-workflows
+
   - repo: https://github.com/maresb/check-json5
     rev: 893a2b5a0a27c3540bd8fcafe2968ccc05237179 # 1.0
     hooks:
@@ -205,6 +211,11 @@ repos:
     hooks:
       - id: detect-private-key
 
+  # - repo: https://github.com/woodruffw/zizmor-pre-commit # TODO: implement this: https://github.com/LabAutomationAndScreening/copier-base-template/issues/95
+  #   rev: b933184438555436e38621f46ceb0c417cbed400  # frozen: v1.13.0
+  #   hooks:
+  #     - id: zizmor
+
   # Linting
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks-markup
@@ -215,7 +226,7 @@ repos:
         exclude: docs/.*\.rst$
 
   - repo: https://github.com/hadolint/hadolint
-    rev: 87de847754330ad47ae16bdfe2d1a757ccb4b4d4  # frozen: v2.13.1
+    rev: 4e697ba704fd23b2409b947a319c19c3ee54d24f  # frozen: v2.14.0
     hooks:
       - id: hadolint-docker
         name: Lint Dockerfiles
@@ -223,7 +234,7 @@ repos:
         description: Runs hadolint to lint Dockerfiles
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 13a6bda8ea7612b3aec844ded16569d424b9a1ab  # frozen: v0.13.0
+    rev: a113f03edeabb71305f025e6e14bd2cd68660e29  # frozen: v0.13.1
     hooks:
       - id: ruff
         name: ruff-src

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Deprecated
 
 
+## [0.2.6] - 2025-10-07
+
+### Fixed
+- Include the vendor files directory in the packaged library
+
 ---
 
 ## [0.2.5] - 2025-09-08

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyalab"
-version = "0.2.5"
+version = "0.2.6"
 description = "Generating programs for Vialab to control an Integra Assist Plus liquid handling robot"
 authors = [
     {name = "Eli Fine"},
@@ -28,9 +28,9 @@ dev = [
     # Specific to this repository
 
     "lxml-stubs>=0.5.1",
-    "syrupy>=4.9.1",
+    "syrupy>=5.0.0",
     "pytest-mock>=3.15.0",
-    "faker>=37.5.3",
+    "faker>=37.8.0",
     "autodoc_pydantic==2.2.0",
 
     # Managed by upstream template
@@ -44,6 +44,7 @@ dev = [
 
 [tool.setuptools]
 license-files = [] # kludge until this bug is fixed https://github.com/pypa/setuptools/issues/4759
+package-data = {"pyalab" = ["vendor_files/**/*.xml"]}
 
 [tool.uv]
 package = true

--- a/ruff-test.toml
+++ b/ruff-test.toml
@@ -15,5 +15,9 @@ ignore = [
     "TRY003", # tests dont need to create a custom exception classes, generally you want to throw an AssertionError with a message anyway
 ]
 
+unfixable = [
+    "SIM117", # pytest.raises context managers should generally be separate from others so they can be very specific about where the error is being raised from, so don't autofix this
+]
+
 [lint.flake8-pytest-style]
 raises-require-match-for = ["*"] # ensures we always have a match for our raises statements so that we validate tests fail for the right reason

--- a/ruff.toml
+++ b/ruff.toml
@@ -45,6 +45,7 @@ ignore = [
     "D102", # Docstrings are not always necessary for public methods
     "D103", # Docstrings are not always necessary for public functions
     "D104", # Docstrings are not always necessary for public packages
+    "D105", # Docstrings are not always necessary for magic methods
     "D106", # Nested classes are usually library-specific and don't always require its own docstring
     "D107", # Init shouldn't need its own docstring, those arguments can be captured in the class level docstring
     "D203", # Ignore D203 because it's a bug https://github.com/PyCQA/pydocstyle/issues/141
@@ -68,10 +69,10 @@ ignore = [
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
 unfixable = [
-                "T201", "T203", # don't automatically delete print statements, just warn about them
-                "RUF100", # don't automatically remove unnecessary suppressions, because that can leave behind a now-stale comment about why the suppression was originally added
-                "FURB136", "PLR1730", # don't automatically replace if statements with min/max functions. Sometimes the if statement is more readable or better for code coverage checking
-            ]
+    "T201", "T203", # don't automatically delete print statements, just warn about them
+    "RUF100", # don't automatically remove unnecessary suppressions, because that can leave behind a now-stale comment about why the suppression was originally added
+    "FURB136", "PLR1730", # don't automatically replace if statements with min/max functions. Sometimes the if statement is more readable or better for code coverage checking
+]
 
 # Allow unused variables if it's an underscore or double underscore.
 dummy-variable-rgx = "^_$|^__$"
@@ -86,7 +87,7 @@ dummy-variable-rgx = "^_$|^__$"
 force-single-line = true
 
 [lint.flake8-builtins]
-builtins-ignorelist = ["id"] # We use the id() builtin little enough that it's okay to shadow it
+builtins-ignorelist = ["id"] # We use the id() builtin rarely enough that it's okay to shadow it
 
 [lint.flake8-annotations]
 mypy-init-return = true # we don't care about annotating all __init__ methods as returning None

--- a/tests/unit/snapshot.py
+++ b/tests/unit/snapshot.py
@@ -11,7 +11,7 @@ class SingleFileXmlSnapshot(SingleFileSnapshotExtension):
     _write_mode = (
         WriteMode.TEXT
     )  # for some reason the default is binary, but it should be text to make diffs easier to read
-    _file_extension = "xml"
+    file_extension = "xml"
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -174,14 +174,14 @@ wheels = [
 
 [[package]]
 name = "faker"
-version = "37.6.0"
+version = "37.8.0"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/cd/f7679c20f07d9e2013123b7f7e13809a3450a18d938d58e86081a486ea15/faker-37.6.0.tar.gz", hash = "sha256:0f8cc34f30095184adf87c3c24c45b38b33ad81c35ef6eb0a3118f301143012c", size = 1907960, upload-time = "2025-08-26T15:56:27.419Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/da/1336008d39e5d4076dddb4e0f3a52ada41429274bf558a3cc28030d324a3/faker-37.8.0.tar.gz", hash = "sha256:090bb5abbec2b30949a95ce1ba6b20d1d0ed222883d63483a0d4be4a970d6fb8", size = 1912113, upload-time = "2025-09-15T20:24:13.592Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/7d/8b50e4ac772719777be33661f4bde320793400a706f5eb214e4de46f093c/faker-37.6.0-py3-none-any.whl", hash = "sha256:3c5209b23d7049d596a51db5d76403a0ccfea6fc294ffa2ecfef6a8843b1e6a7", size = 1949837, upload-time = "2025-08-26T15:56:25.33Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/11/02ebebb09ff2104b690457cb7bc6ed700c9e0ce88cf581486bb0a5d3c88b/faker-37.8.0-py3-none-any.whl", hash = "sha256:b08233118824423b5fc239f7dd51f145e7018082b4164f8da6a9994e1f1ae793", size = 1953940, upload-time = "2025-09-15T20:24:11.482Z" },
 ]
 
 [[package]]
@@ -348,7 +348,7 @@ wheels = [
 
 [[package]]
 name = "pyalab"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "inflection" },
@@ -380,7 +380,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "autodoc-pydantic", specifier = "==2.2.0" },
-    { name = "faker", specifier = ">=37.5.3" },
+    { name = "faker", specifier = ">=37.8.0" },
     { name = "lxml-stubs", specifier = ">=0.5.1" },
     { name = "pyright", specifier = ">=1.1.405" },
     { name = "pytest", specifier = ">=8.4.2" },
@@ -388,7 +388,7 @@ dev = [
     { name = "pytest-mock", specifier = ">=3.15.0" },
     { name = "pytest-randomly", specifier = ">=4.0.1" },
     { name = "sphinx", specifier = "==8.1.3" },
-    { name = "syrupy", specifier = ">=4.9.1" },
+    { name = "syrupy", specifier = ">=5.0.0" },
 ]
 
 [[package]]
@@ -472,15 +472,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.405"
+version = "1.1.406"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/6c/ba4bbee22e76af700ea593a1d8701e3225080956753bee9750dcc25e2649/pyright-1.1.405.tar.gz", hash = "sha256:5c2a30e1037af27eb463a1cc0b9f6d65fec48478ccf092c1ac28385a15c55763", size = 4068319, upload-time = "2025-09-04T03:37:06.776Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/6b4fbdd1fef59a0292cbb99f790b44983e390321eccbc5921b4d161da5d1/pyright-1.1.406.tar.gz", hash = "sha256:c4872bc58c9643dac09e8a2e74d472c62036910b3bd37a32813989ef7576ea2c", size = 4113151, upload-time = "2025-10-02T01:04:45.488Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/1a/524f832e1ff1962a22a1accc775ca7b143ba2e9f5924bb6749dce566784a/pyright-1.1.405-py3-none-any.whl", hash = "sha256:a2cb13700b5508ce8e5d4546034cb7ea4aedb60215c6c33f56cec7f53996035a", size = 5905038, upload-time = "2025-09-04T03:37:04.913Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a2/e309afbb459f50507103793aaef85ca4348b66814c86bc73908bdeb66d12/pyright-1.1.406-py3-none-any.whl", hash = "sha256:1d81fb43c2407bf566e97e57abb01c811973fdb21b2df8df59f870f688bdca71", size = 5980982, upload-time = "2025-10-02T01:04:43.137Z" },
 ]
 
 [[package]]
@@ -653,14 +653,14 @@ wheels = [
 
 [[package]]
 name = "syrupy"
-version = "4.9.1"
+version = "5.0.0"
 source = { registry = "https://pypi.org/simple/" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/f8/022d8704a3314f3e96dbd6bbd16ebe119ce30e35f41aabfa92345652fceb/syrupy-4.9.1.tar.gz", hash = "sha256:b7d0fcadad80a7d2f6c4c71917918e8ebe2483e8c703dfc8d49cdbb01081f9a4", size = 52492, upload-time = "2025-03-24T01:36:37.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/90/1a442d21527009d4b40f37fe50b606ebb68a6407142c2b5cc508c34b696b/syrupy-5.0.0.tar.gz", hash = "sha256:3282fe963fa5d4d3e47231b16d1d4d0f4523705e8199eeb99a22a1bc9f5942f2", size = 48881, upload-time = "2025-09-28T21:15:12.783Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/9d/aef9ec5fd5a4ee2f6a96032c4eda5888c5c7cec65cef6b28c4fc37671d88/syrupy-4.9.1-py3-none-any.whl", hash = "sha256:b94cc12ed0e5e75b448255430af642516842a2374a46936dd2650cfb6dd20eda", size = 52214, upload-time = "2025-03-24T01:36:35.278Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/6c68aad2ccfce6e2eeebbf5bb709d0240592eb51ff142ec4c8fbf3c2460a/syrupy-5.0.0-py3-none-any.whl", hash = "sha256:c848e1a980ca52a28715cd2d2b4d434db424699c05653bd1158fb31cf56e9546", size = 49087, upload-time = "2025-09-28T21:15:11.639Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
 ## Why is this change necessary?
The XML definition files weren't being included in the packaged library and so weren't available after a `pip install`


 ## How does this change address the issue?
Adds them as specified in pyproject.toml


 ## What side effects does this change have?
the wheel is larger


 ## How is this change tested?
Local build and ensuring they're included


 ## Other
Pulled in some copier template updates to bump versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Packaged library now includes vendor files directory to ensure all required assets are distributed.

- Chores
  - Bumped package to 0.2.6 and refreshed development dependencies and tooling versions.
  - Improved development container setup and installer resilience.
  - Updated CI workflows to avoid persisting credentials and added context visibility.
  - Refreshed pre-commit configuration, including formatter source and workflow validation.
  - Adjusted linter settings for clearer, more consistent checks.

- Documentation
  - Updated changelog with 0.2.6 entry detailing the packaging fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->